### PR TITLE
Fixes #13. Configurable traffic maximum

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ If you are using the scripts on a different Fritz!Box model please let me know b
 
   fritzbox\_traffic shows you the traffic of the WAN interface (requires fritzconnection)  
   ![http://i.imgur.com/8BwNMOL.png](http://i.imgur.com/8BwNMOL.png)
+
+  If you do not want to show the interface maximum values, add the following to your plugin-configuration:
+
+    env.traffic_remove_max true
   
 ## fritzbox\_connection\_uptime
 

--- a/fritzbox_traffic.py
+++ b/fritzbox_traffic.py
@@ -32,13 +32,14 @@ def print_values():
     up_traffic = conn.call_action('WANCommonInterfaceConfig', 'GetTotalBytesSent')['NewTotalBytesSent']
     print ('up.value %d' % up_traffic)
 
-    max_down_traffic = conn.call_action('WANCommonInterfaceConfig', 'GetCommonLinkProperties')[
-        'NewLayer1DownstreamMaxBitRate']
-    print ('maxdown.value %d' % max_down_traffic)
+    if not os.environ.get('traffic_remove_max'):
+        max_down_traffic = conn.call_action('WANCommonInterfaceConfig', 'GetCommonLinkProperties')[
+            'NewLayer1DownstreamMaxBitRate']
+        print ('maxdown.value %d' % max_down_traffic)
 
-    max_up_traffic = conn.call_action('WANCommonInterfaceConfig', 'GetCommonLinkProperties')[
-        'NewLayer1UpstreamMaxBitRate']
-    print ('maxup.value %d' % max_up_traffic)
+        max_up_traffic = conn.call_action('WANCommonInterfaceConfig', 'GetCommonLinkProperties')[
+            'NewLayer1UpstreamMaxBitRate']
+        print ('maxup.value %d' % max_up_traffic)
 
 
 def print_config():
@@ -61,14 +62,15 @@ def print_config():
     print "up.max 1000000000"
     print "up.negative down"
     print "up.info Traffic of the WAN interface."
-    print "maxdown.label received"
-    print "maxdown.type GAUGE"
-    print "maxdown.graph no"
-    print "maxup.label MAX"
-    print "maxup.type GAUGE"
-    print "maxup.negative maxdown"
-    print "maxup.draw LINE1"
-    print "maxup.info Maximum speed of the WAN interface."
+    if not os.environ.get('traffic_remove_max'):
+        print "maxdown.label received"
+        print "maxdown.type GAUGE"
+        print "maxdown.graph no"
+        print "maxup.label MAX"
+        print "maxup.type GAUGE"
+        print "maxup.negative maxdown"
+        print "maxup.draw LINE1"
+        print "maxup.info Maximum speed of the WAN interface."
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If you set the `traffic_remove_max` environment variable, the maximum value is removed from the graph