### PR TITLE
README: add lxml dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ If you are using the scripts on a different Fritz!Box model please let me know b
 
 ## Installation & Configuration
 
+0. Pre-requesite for all plugins is the [lxml](https://lxml.de/) package. To install it
+
+        pip install lxml
+        
 1. Pre-requesites for the fritzbox\_traffic and fritzbox\_uptime plugins are the [fritzconnection](https://pypi.python.org/pypi/fritzconnection) and [requests](https://pypi.python.org/pypi/requests) package. To install it
 
         pip install fritzconnection


### PR DESCRIPTION
Pre-requesite for all plugins is the [lxml](https://lxml.de/) package.