### PR TITLE
fritzbox_helper: TLS, username authentication and custom form fields

### DIFF
--- a/fritzbox_helper.py
+++ b/fritzbox_helper.py
@@ -27,7 +27,7 @@ import requests
 from lxml import etree
 
 
-def get_session_id(server, password, port=80):
+def get_session_id(server, password, port=80, username=None):
     """Obtains the session id after login into the Fritzbox.
     See https://avm.de/fileadmin/user_upload/Global/Service/Schnittstellen/AVM_Technical_Note_-_Session_ID.pdf
     for deteils (in German).
@@ -61,6 +61,9 @@ def get_session_id(server, password, port=80):
         params['response'] = response_bf
     else:
         return session_id
+
+    if username is not None:
+        params['username'] = username
 
     headers = {"Accept": "text/html,application/xhtml+xml,application/xml",
                "Content-Type": "application/x-www-form-urlencoded"}

--- a/fritzbox_helper.py
+++ b/fritzbox_helper.py
@@ -49,6 +49,7 @@ def get_session_id(server, password, port=80):
         print(err)
         sys.exit(1)
 
+    params = {}
     root = etree.fromstring(r.content)
     session_id = root.xpath('//SessionInfo/SID/text()')[0]
     if session_id == "0000000000000000":
@@ -57,15 +58,16 @@ def get_session_id(server, password, port=80):
         m = hashlib.md5()
         m.update(challenge_bf)
         response_bf = '{}-{}'.format(challenge, m.hexdigest().lower())
+        params['response'] = response_bf
     else:
         return session_id
 
     headers = {"Accept": "text/html,application/xhtml+xml,application/xml",
                "Content-Type": "application/x-www-form-urlencoded"}
 
-    url = 'http://{}:{}/login_sid.lua?&response={}'.format(server, port, response_bf)
+    url = 'http://{}:{}/login_sid.lua'.format(server, port)
     try:
-        r = requests.get(url, headers=headers)
+        r = requests.get(url, headers=headers, params=params)
         r.raise_for_status()
     except requests.exceptions.HTTPError as err:
         print(err)
@@ -91,10 +93,11 @@ def get_page_content(server, session_id, page, port=80):
 
     headers = {"Accept": "application/xml",
                "Content-Type": "text/plain"}
+    params = {"sid": session_id}
 
-    url = 'http://{}:{}/{}?sid={}'.format(server, port, page, session_id)
+    url = 'http://{}:{}/{}'.format(server, port, page)
     try:
-        r = requests.get(url, headers=headers)
+        r = requests.get(url, headers=headers, params=params)
         r.raise_for_status()
     except requests.exceptions.HTTPError as err:
         print(err)

--- a/fritzbox_helper.py
+++ b/fritzbox_helper.py
@@ -122,7 +122,7 @@ def get_page_content(server, session_id, page, port=0, tls=False):
     return r.content
 
 
-def get_xhr_content(server, session_id, page=None, port=0, tls=False):
+def get_xhr_content(server, session_id, page=None, port=0, tls=False, data={}):
     """Fetches the xhr content from the Fritzbox and returns its content
 
     :param server: the ip address of the Fritzbox
@@ -137,12 +137,13 @@ def get_xhr_content(server, session_id, page=None, port=0, tls=False):
                "Content-Type": "application/x-www-form-urlencoded"}
 
     url = '{}/data.lua'.format(base_uri)
-    data = {"xhr": 1,
+    data.update({
+            "xhr": 1,
             "sid": session_id,
             "lang": "en",
             "xhrId": "all",
             "no_sidrenew": ""
-            }
+            })
 
     if page is not None:
         data["page"] = page

--- a/fritzbox_helper.py
+++ b/fritzbox_helper.py
@@ -26,8 +26,6 @@ import sys
 import requests
 from lxml import etree
 
-USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:10.0) Gecko/20100101 Firefox/10.0"
-
 
 def get_session_id(server, password, port=80):
     """Obtains the session id after login into the Fritzbox.
@@ -41,8 +39,7 @@ def get_session_id(server, password, port=80):
     """
 
     headers = {"Accept": "application/xml",
-               "Content-Type": "text/plain",
-               "User-Agent": USER_AGENT}
+               "Content-Type": "text/plain"}
 
     url = 'http://{}:{}/login_sid.lua'.format(server, port)
     try:
@@ -64,8 +61,7 @@ def get_session_id(server, password, port=80):
         return session_id
 
     headers = {"Accept": "text/html,application/xhtml+xml,application/xml",
-               "Content-Type": "application/x-www-form-urlencoded",
-               "User-Agent": USER_AGENT}
+               "Content-Type": "application/x-www-form-urlencoded"}
 
     url = 'http://{}:{}/login_sid.lua?&response={}'.format(server, port, response_bf)
     try:
@@ -94,8 +90,7 @@ def get_page_content(server, session_id, page, port=80):
     """
 
     headers = {"Accept": "application/xml",
-               "Content-Type": "text/plain",
-               "User-Agent": USER_AGENT}
+               "Content-Type": "text/plain"}
 
     url = 'http://{}:{}/{}?sid={}'.format(server, port, page, session_id)
     try:
@@ -118,8 +113,7 @@ def get_xhr_content(server, session_id, page, port=80):
     """
 
     headers = {"Accept": "application/xml",
-               "Content-Type": "application/x-www-form-urlencoded",
-               "User-Agent": USER_AGENT}
+               "Content-Type": "application/x-www-form-urlencoded"}
 
     url = 'http://{}:{}/data.lua'.format(server, port)
     data = {"xhr": 1,

--- a/fritzbox_helper.py
+++ b/fritzbox_helper.py
@@ -122,7 +122,7 @@ def get_page_content(server, session_id, page, port=0, tls=False):
     return r.content
 
 
-def get_xhr_content(server, session_id, page, port=0, tls=False):
+def get_xhr_content(server, session_id, page=None, port=0, tls=False):
     """Fetches the xhr content from the Fritzbox and returns its content
 
     :param server: the ip address of the Fritzbox
@@ -140,10 +140,13 @@ def get_xhr_content(server, session_id, page, port=0, tls=False):
     data = {"xhr": 1,
             "sid": session_id,
             "lang": "en",
-            "page": page,
             "xhrId": "all",
             "no_sidrenew": ""
             }
+
+    if page is not None:
+        data["page"] = page
+
     try:
         r = requests.post(url, data=data, headers=headers)
     except (requests.exceptions.HTTPError,


### PR DESCRIPTION
First, I'd like to thank you for fritzbox-munin!

I don't use munin, but I found your repository looking for a library implementing basic session ID handling for fritzboxes.

Summary of changes:
* Add optional TLS connection
* Add authentication method using username and password
* Make use of `params` parameter of `requests.get()`
* Remove fake User-Agent

If you'd like to try a TLS connection from a Debian-based system, you might want to set the following environment variable:
`REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt`