### PR TITLE
Added support for Fritzbox Model 6490 Cable

### DIFF
--- a/fritzbox_traffic.py
+++ b/fritzbox_traffic.py
@@ -20,7 +20,14 @@ import sys
 from fritzconnection import FritzConnection
 
 
-def model_needs_login(model: str) -> bool:
+def model_needs_login(model):
+    """
+    Checks if provided fritzbox model is in the list of devices which need an authenticated login
+    to extract traffic data.
+
+    :param model: String describing the fritzbox model; as returned from FritzConnection().modelname
+    :return bool
+    """
     models_require_login = [
         "FRITZ!Box 6490 Cable",
     ]

--- a/fritzbox_traffic.py
+++ b/fritzbox_traffic.py
@@ -20,11 +20,26 @@ import sys
 from fritzconnection import FritzConnection
 
 
+def model_needs_login(model: str) -> bool:
+    models_require_login = [
+        "FRITZ!Box 6490 Cable",
+    ]
+    for m in models_require_login:
+        if model.startswith(m):
+            return True
+    return False
+
+
 def print_values():
     try:
         conn = FritzConnection(address=os.environ['fritzbox_ip'])
+        if model_needs_login(conn.modelname):
+            conn = FritzConnection(address=os.environ['fritzbox_ip'],
+                                   user='dslf-config',
+                                   password=os.environ['fritzbox_password'],
+                                   )
     except Exception as e:
-        sys.exit("Couldn't get WAN traffic")
+        sys.exit("Couldn't establish connection to fritzbox")
 
     down_traffic = conn.call_action('WANCommonInterfaceConfig', 'GetTotalBytesReceived')['NewTotalBytesReceived']
     print('down.value %d' % down_traffic)


### PR DESCRIPTION
Model "Fritzbox Model 6490 Cable" required login to extract the traffic data.
Added a workaround to allow for the identification of those models and to use a user & password-based extraction method.