### PR TITLE
Support old firmware 6.86 when fetching wifi devices

### DIFF
--- a/fritzbox_wifi_devices.py
+++ b/fritzbox_wifi_devices.py
@@ -11,7 +11,7 @@
   env.fritzbox_ip [ip address of the fritzbox]
   env.fritzbox_username [fritzbox username]
   env.fritzbox_password [fritzbox password]
-  
+
   This plugin supports the following munin configuration parameters:
   #%# family=auto contrib
   #%# capabilities=autoconf
@@ -39,6 +39,14 @@ def get_connected_wifi_devices():
 
     session_id = fh.get_session_id(server, username, password)
     xhr_data = fh.get_xhr_content(server, session_id, PAGE)
+    if xhr_data[0:8] == b"<script>":
+        #firmware 6.86
+        m = re.search(pattern, xhr_data.decode("utf-8"))
+        if m:
+            connected_devices = int(m.group(1))
+            print("wifi.value %d" % connected_devices)
+        return
+
     data = json.loads(xhr_data)
     m = re.search(pattern, data["data"]["drain"][2]["statuses"][-1])
     if m:


### PR DESCRIPTION
Resolves: https://github.com/Tafkas/fritzbox-munin/issues/57